### PR TITLE
Move from wrapt to wraps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Backward-incompatible changes:
 - Support for Python 2.7, 3.5, and 3.6 has been dropped.
 - The *loop* argument has been removed from ``prometheus_async.aio.start_http_server()``.
 - Since we now run on modern Python versions only, the usage of *wrapt* has been replaced by ``functools.wraps()``.
-`#24 <https://github.com/hynek/prometheus-async/pull/24>`_
+  `#24 <https://github.com/hynek/prometheus-async/pull/24>`_
 
 
 Deprecations:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Backward-incompatible changes:
 - Support for Python 2.7, 3.5, and 3.6 has been dropped.
 - The *loop* argument has been removed from ``prometheus_async.aio.start_http_server()``.
 - Since we now run on modern Python versions only, the usage of *wrapt* has been replaced by ``functools.wraps()``.
+`#24 <https://github.com/hynek/prometheus-async/pull/24>`_
 
 
 Deprecations:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Backward-incompatible changes:
 
 - Support for Python 2.7, 3.5, and 3.6 has been dropped.
 - The *loop* argument has been removed from ``prometheus_async.aio.start_http_server()``.
+- Since we now run on modern Python versions only, the usage of *wrapt* has been replaced by ``functools.wraps()``.
 
 
 Deprecations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ requires-python = ">=3.7"
 dependencies = [
     "prometheus_client >= 0.8.0",
     "typing_extensions >= 3.10.0; python_version<'3.10'",
-    "wrapt",
 ]
 license = { file = "LICENSE" }
 readme = { content-type = "text/x-rst", file = "README.rst" }

--- a/src/prometheus_async/aio/_decorators.py
+++ b/src/prometheus_async/aio/_decorators.py
@@ -86,7 +86,7 @@ def time(
 @overload
 def count_exceptions(
     metric: IncDecrementer, *, exc: type[BaseException] = BaseException
-) -> Callable[[Callable[P, R]], Callable[P, Awaitable[R]]]:
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
     ...
 
 
@@ -105,7 +105,9 @@ def count_exceptions(
     future: Awaitable[T] | None = None,
     *,
     exc: type[BaseException] = BaseException,
-) -> Callable[[Callable[P, R]], Callable[P, Awaitable[R]]] | Awaitable[T]:
+) -> Callable[
+    [Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]
+] | Awaitable[T]:
     r"""
     Call ``metric.inc()`` whenever *exc* is caught.
 
@@ -115,9 +117,11 @@ def count_exceptions(
     """
     if future is None:
 
-        def count(wrapped: Callable[P, R]) -> Callable[P, Awaitable[R]]:
+        def count(
+            wrapped: Callable[P, Awaitable[T]]
+        ) -> Callable[P, Awaitable[T]]:
             @wraps(wrapped)
-            async def inner(*args: P.args, **kw: P.kwargs) -> R:
+            async def inner(*args: P.args, **kw: P.kwargs) -> T:
                 try:
                     rv = await wrapped(*args, **kw)
                 except exc:

--- a/src/prometheus_async/aio/_decorators.py
+++ b/src/prometheus_async/aio/_decorators.py
@@ -146,7 +146,7 @@ def count_exceptions(
 @overload
 def track_inprogress(
     metric: IncDecrementer,
-) -> Callable[[Callable[P, R]], Callable[P, Awaitable[R]]]:
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
     ...
 
 
@@ -159,7 +159,9 @@ def track_inprogress(
 
 def track_inprogress(
     metric: IncDecrementer, future: Awaitable[T] | None = None
-) -> Callable[[Callable[P, R]], Callable[P, Awaitable[R]]] | Awaitable[T]:
+) -> Callable[
+    [Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]
+] | Awaitable[T]:
     r"""
     Call ``metrics.inc()`` on entry and ``metric.dec()`` on exit.
 
@@ -169,9 +171,11 @@ def track_inprogress(
     """
     if future is None:
 
-        def track(wrapped: Callable[P, R]) -> Callable[P, Awaitable[R]]:
+        def track(
+            wrapped: Callable[P, Awaitable[T]]
+        ) -> Callable[P, Awaitable[T]]:
             @wraps(wrapped)
-            async def inner(*args: P.args, **kw: P.kwargs) -> R:
+            async def inner(*args: P.args, **kw: P.kwargs) -> T:
                 metric.inc()
                 try:
                     rv = await wrapped(*args, **kw)

--- a/src/prometheus_async/aio/_decorators.py
+++ b/src/prometheus_async/aio/_decorators.py
@@ -80,8 +80,7 @@ def time(
 
         async def measure_future(start_time: float) -> T:
             try:
-                rv = await f
-                return rv
+                return await f
             finally:
                 observe(start_time)
 
@@ -129,12 +128,10 @@ def count_exceptions(
             @wraps(wrapped)
             async def inner(*args: P.args, **kw: P.kwargs) -> T:
                 try:
-                    rv = await wrapped(*args, **kw)
+                    return await wrapped(*args, **kw)
                 except exc:
                     metric.inc()
                     raise
-
-                return rv
 
             return inner
 
@@ -144,11 +141,10 @@ def count_exceptions(
 
         async def count_future() -> T:
             try:
-                rv = await f
+                return await f
             except exc:
                 metric.inc()
                 raise
-            return rv
 
         return count_future()
 
@@ -188,11 +184,9 @@ def track_inprogress(
             async def inner(*args: P.args, **kw: P.kwargs) -> T:
                 metric.inc()
                 try:
-                    rv = await wrapped(*args, **kw)
+                    return await wrapped(*args, **kw)
                 finally:
                     metric.dec()
-
-                return rv
 
             return inner
 
@@ -203,10 +197,8 @@ def track_inprogress(
 
         async def track_future() -> T:
             try:
-                rv = await f
+                return await f
             finally:
                 metric.dec()
-
-            return rv
 
         return track_future()

--- a/src/prometheus_async/aio/_decorators.py
+++ b/src/prometheus_async/aio/_decorators.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 
 from functools import wraps
 from time import perf_counter
-from typing import TYPE_CHECKING, Awaitable, Callable, overload
+from typing import TYPE_CHECKING, overload
 
 
 if TYPE_CHECKING:
+    from typing import Awaitable, Callable
+
     from ..types import IncDecrementer, Observer, P, T
 
 

--- a/src/prometheus_async/aio/_decorators.py
+++ b/src/prometheus_async/aio/_decorators.py
@@ -22,17 +22,17 @@ from __future__ import annotations
 
 from functools import wraps
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, overload
-
-from wrapt import decorator
+from typing import TYPE_CHECKING, Awaitable, Callable, overload
 
 
 if TYPE_CHECKING:
-    from ..types import IncDecrementer, Observer, P, R, T
+    from ..types import IncDecrementer, Observer, P, T
 
 
 @overload
-def time(metric: Observer) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def time(
+    metric: Observer,
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
     ...
 
 
@@ -43,7 +43,9 @@ def time(metric: Observer, future: Awaitable[T]) -> Awaitable[T]:
 
 def time(
     metric: Observer, future: Awaitable[T] | None = None
-) -> Awaitable[T] | Callable[[Callable[P, R]], Callable[P, R]]:
+) -> Awaitable[T] | Callable[
+    [Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]
+]:
     r"""
     Call ``metric.observe(time)`` with the runtime in seconds.
 
@@ -57,22 +59,24 @@ def time(
 
     if future is None:
 
-        @decorator
-        async def time_decorator(
-            wrapped: Callable[..., R], _: Any, args: Any, kw: Any
-        ) -> R:
-            start_time = perf_counter()
-            try:
-                rv = await wrapped(*args, **kw)
-                return rv
-            finally:
-                observe(start_time)
+        def measure(
+            wrapped: Callable[P, Awaitable[T]]
+        ) -> Callable[P, Awaitable[T]]:
+            @wraps(wrapped)
+            async def inner(*args: P.args, **kw: P.kwargs) -> T:
+                start_time = perf_counter()
+                try:
+                    return await wrapped(*args, **kw)
+                finally:
+                    observe(start_time)
 
-        return time_decorator
+            return inner
+
+        return measure
     else:
         f = future
 
-        async def measure(start_time: float) -> T:
+        async def measure_future(start_time: float) -> T:
             try:
                 rv = await f
                 return rv
@@ -80,7 +84,7 @@ def time(
                 observe(start_time)
 
         start_time = perf_counter()
-        return measure(start_time)
+        return measure_future(start_time)
 
 
 @overload

--- a/src/prometheus_async/tx/_decorators.py
+++ b/src/prometheus_async/tx/_decorators.py
@@ -84,12 +84,12 @@ def time(
         return measure
     else:
 
-        def observe(value: T) -> T:
+        def measure_deferred(value: T) -> T:
             metric.observe(perf_counter() - start_time)
             return value
 
         start_time = perf_counter()
-        return deferred.addBoth(observe)  # type: ignore
+        return deferred.addBoth(measure_deferred)  # type: ignore
 
 
 @overload

--- a/src/prometheus_async/types.py
+++ b/src/prometheus_async/types.py
@@ -49,8 +49,6 @@ __all__ = [
 P = ParamSpec("P")
 R = TypeVar("R", bound=Awaitable)
 T = TypeVar("T")
-C = TypeVar("C", bound=Callable)
-
 
 Deregisterer = Callable[[], Awaitable[None]]
 


### PR DESCRIPTION
We're 3.7-only now and it's nice to drop a C-based dependency every now and then.